### PR TITLE
 Improve UI

### DIFF
--- a/api/404.go
+++ b/api/404.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"bytes"
+	"html/template"
+	"net/http"
+)
+
+func ForOForHandler(w http.ResponseWriter, r *http.Request) {
+	owner := r.URL.Query().Get("owner")
+	repo := r.URL.Query().Get("repo")
+	issue := r.URL.Query().Get("issue")
+
+	tmpl := template.Must(template.ParseFS(templates, "templates/404.html"))
+	var tpl bytes.Buffer
+	tmpl.Execute(&tpl, templateInfo{owner, repo, issue, true})
+	w.Write(tpl.Bytes())
+	w.WriteHeader(http.StatusBadRequest)
+}

--- a/api/index.go
+++ b/api/index.go
@@ -1,67 +1,37 @@
 package api
 
 import (
-    "bytes"
-    "embed"
-    "github.com/ioki-mobility/summaraizer"
-    "html/template"
-    "log"
-    "net/http"
-    "os"
+	"bytes"
+	"embed"
+	"html/template"
+	"net/http"
 )
-
-const aiPrompt = `
-I give you a discussion and you give me a summary.
-Each comment of the discussion is wrapped in a <comment author="author-name"> tag.
-Your summary should not be longer than 1200 chars.
-Here is the discussion:
-{{ range $comment := . }}
-<comment author="{{ $comment.Author }}">{{ $comment.Body }}</comment>
-{{end}}
-`
-
-var openAiToken = os.Getenv("OPENAI_API_TOKEN")
 
 //go:embed templates/*
 var templates embed.FS
 
-func Handler(w http.ResponseWriter, r *http.Request) {
-    owner := r.URL.Query().Get("owner")
-    repo := r.URL.Query().Get("repo")
-    issue := r.URL.Query().Get("issue")
-
-    if owner != "" && repo != "" && issue != "" {
-        summary := fetchAndSummarize(owner, repo, issue)
-        tmpl := template.Must(template.ParseFS(templates, "templates/comment.html"))
-        var tpl bytes.Buffer
-        tmpl.Execute(&tpl, summary)
-        w.Write(tpl.Bytes())
-        w.WriteHeader(http.StatusOK)
-        return
-    }
-
-    w.Write([]byte("houston we have a problem"))
-    w.WriteHeader(http.StatusForbidden)
+type templateInfo struct {
+	Owner string
+	Repo  string
+	Issue string
+	Error bool
 }
 
-func fetchAndSummarize(owner, repo, issue string) string {
-    buffer := bytes.Buffer{}
-    gh := summaraizer.GitHub{
-        RepoOwner:   owner,
-        RepoName:    repo,
-        IssueNumber: issue,
-    }
-    gh.Fetch(&buffer)
+func IndexHandler(w http.ResponseWriter, r *http.Request) {
+	owner := r.URL.Query().Get("owner")
+	repo := r.URL.Query().Get("repo")
+	issue := r.URL.Query().Get("issue")
 
-    openAi := summaraizer.OpenAi{
-        Model:    "gpt-4o-mini",
-        Prompt:   aiPrompt,
-        ApiToken: openAiToken,
-    }
-    summarization, err := openAi.Summarize(&buffer)
-    if err != nil {
-        log.Fatal(err)
-    }
+	tmpl := template.Must(template.ParseFS(templates, "templates/comment.html"))
+	var tpl bytes.Buffer
+	if owner != "" && repo != "" && issue != "" {
+		tmpl.Execute(&tpl, templateInfo{owner, repo, issue, false})
+		w.Write(tpl.Bytes())
+		w.WriteHeader(http.StatusOK)
+		return
+	}
 
-    return summarization
+	tmpl.Execute(&tpl, templateInfo{owner, repo, issue, true})
+	w.Write(tpl.Bytes())
+	w.WriteHeader(http.StatusBadRequest)
 }

--- a/api/summary.go
+++ b/api/summary.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/ioki-mobility/summaraizer"
+)
+
+const aiPrompt = `
+I give you a discussion and you give me a summary.
+Each comment of the discussion is wrapped in a <comment author="author-name"> tag.
+Your summary should not be longer than 1200 chars.
+Here is the discussion:
+{{ range $comment := . }}
+<comment author="{{ $comment.Author }}">{{ $comment.Body }}</comment>
+{{end}}
+`
+
+var openAiToken = os.Getenv("OPENAI_API_TOKEN")
+
+type RequestData struct {
+	Owner string `json:"owner"`
+	Repo  string `json:"repo"`
+	Issue string `json:"issue"`
+}
+
+func SummaryHandler(w http.ResponseWriter, r *http.Request) {
+	// Read the owner, repo and issue from a POST json that has owner, repo and issue fields
+	// in golang.
+	// The Request should have everything included we need
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.Write([]byte(`{ "summarization": "houston we have a problem" }`))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	var requestData RequestData
+	err = json.Unmarshal(bodyBytes, &requestData)
+	if err != nil {
+		w.Write([]byte(`{ "summarization": "houston we have a problem" }`))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if requestData.Owner != "" && requestData.Repo != "" && requestData.Issue != "" {
+		summary, err := fetchAndSummarize(requestData.Owner, requestData.Repo, requestData.Issue)
+		if err != nil {
+			w.Write([]byte(`{ "summarization": "houston we have a problem" }`))
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		summaryBase64 := base64.StdEncoding.EncodeToString([]byte(summary))
+		w.Write([]byte(`{ "summarization": "` + summaryBase64 + `" }`))
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	w.Write([]byte(`{ "summarization": "houston we have a problem" }`))
+	w.WriteHeader(http.StatusForbidden)
+}
+
+func fetchAndSummarize(owner, repo, issue string) (string, error) {
+	buffer := bytes.Buffer{}
+	gh := summaraizer.GitHub{
+		RepoOwner:   owner,
+		RepoName:    repo,
+		IssueNumber: issue,
+	}
+	err := gh.Fetch(&buffer)
+	if err != nil {
+		return "", err
+	}
+
+	openAi := summaraizer.OpenAi{
+		Model:    "gpt-4o-mini",
+		Prompt:   aiPrompt,
+		ApiToken: openAiToken,
+	}
+	summarization, err := openAi.Summarize(&buffer)
+	if err != nil {
+		return "", err
+	}
+
+	return summarization, nil
+}

--- a/api/templates/404.html
+++ b/api/templates/404.html
@@ -1,0 +1,97 @@
+<!--
+I have no idea what happen here, all of this was of course build by AI.
+To be specific by v0.dev! 
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GitHub Summary</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+            margin: 0;
+            padding: 20px;
+        }
+        .comment-container {
+            max-width: 780px;
+            margin: 0 auto;
+            display: flex;
+        }
+        .avatar {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            margin-right: 15px;
+        }
+        .comment-content {
+            flex-grow: 1;
+            border: 1px solid #d0d7de;
+            border-radius: 6px;
+            position: relative;
+        }
+        .comment-content::before {
+            content: "";
+            position: absolute;
+            top: 11px;
+            left: -8px;
+            border-width: 8px 8px 8px 0;
+            border-style: solid;
+            border-color: transparent #d0d7de transparent transparent;
+        }
+        .comment-content::after {
+            content: "";
+            position: absolute;
+            top: 11px;
+            left: -7px;
+            border-width: 8px 8px 8px 0;
+            border-style: solid;
+            border-color: transparent #f1f8ff transparent transparent;
+        }
+        .comment-header {
+            display: flex;
+            align-items: center;
+            padding: 8px 16px;
+            background-color: #f6f8fa;
+            border-bottom: 1px solid #d0d7de;
+            border-top-left-radius: 6px;
+            border-top-right-radius: 6px;
+        }
+        .comment-meta {
+            flex-grow: 1;
+        }
+        .comment-author {
+            font-weight: 600;
+            color: #24292f;
+            font-size: 14px;
+        }
+        .comment-time {
+            color: #57606a;
+            font-size: 12px;
+        }
+        .comment-body {
+            padding: 20px;
+            font-size: 14px;
+            color: #24292f;
+            line-height: 1.5;
+        }
+    </style>
+</head>
+<body>
+    <div class="comment-container">
+        <img src="https://github.com/identicons/StefMa.png" alt="avatar" class="avatar">
+        <div class="comment-content">
+            <div class="comment-header">
+                <div class="comment-meta">
+                    <span class="comment-author">GitHubSummary[bot]</span>
+                    <span class="comment-time">just now</span>
+                </div>
+            </div>
+            <div class="comment-body">
+                ☠️ Something went wrong ☠️
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/api/templates/comment.html
+++ b/api/templates/comment.html
@@ -1,0 +1,98 @@
+<!--
+I have no idea what happen here, all of this was of course build by AI.
+To be specific by v0.dev! 
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GitHub Summary</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+            margin: 0;
+            padding: 20px;
+        }
+        .comment-container {
+            max-width: 780px;
+            margin: 0 auto;
+            display: flex;
+        }
+        .avatar {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            margin-right: 15px;
+        }
+        .comment-content {
+            flex-grow: 1;
+            border: 1px solid #d0d7de;
+            border-radius: 6px;
+            position: relative;
+        }
+        .comment-content::before {
+            content: "";
+            position: absolute;
+            top: 11px;
+            left: -8px;
+            border-width: 8px 8px 8px 0;
+            border-style: solid;
+            border-color: transparent #d0d7de transparent transparent;
+        }
+        .comment-content::after {
+            content: "";
+            position: absolute;
+            top: 11px;
+            left: -7px;
+            border-width: 8px 8px 8px 0;
+            border-style: solid;
+            border-color: transparent #f1f8ff transparent transparent;
+        }
+        .comment-header {
+            display: flex;
+            align-items: center;
+            padding: 8px 16px;
+            background-color: #f6f8fa;
+            border-bottom: 1px solid #d0d7de;
+            border-top-left-radius: 6px;
+            border-top-right-radius: 6px;
+        }
+        .comment-meta {
+            flex-grow: 1;
+        }
+        .comment-author {
+            font-weight: 600;
+            color: #24292f;
+            font-size: 14px;
+        }
+        .comment-time {
+            color: #57606a;
+            font-size: 12px;
+        }
+        .comment-body {
+            padding: 20px;
+            font-size: 14px;
+            color: #24292f;
+            line-height: 1.5;
+        }
+    </style>
+</head>
+<body>
+    <div class="comment-container">
+        <img src="https://github.com/identicons/StefMa.png" alt="avatar" class="avatar">
+        <div class="comment-content">
+            <div class="comment-header">
+                <div class="comment-meta">
+                    <span class="comment-author">StefMa</span>
+                    <span class="comment-time">just now</span>
+                </div>
+            </div>
+            <div class="comment-body">
+                <sub>This is a AI generated summarization, powered by <a href="https://github.com/ioki-mobility/summaraizer">summaraizer</a>:</sub></br></br>
+                {{ . }}
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/api/templates/comment.html
+++ b/api/templates/comment.html
@@ -77,6 +77,38 @@ To be specific by v0.dev!
             line-height: 1.5;
         }
     </style>
+    <script>
+        if ({{ .Error }}) {
+            document.querySelector('.comment-body').innerHTML = "☠️ Something went wrong ☠️"
+        } else {
+            fetch('/api/summary', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    owner: "{{ .Owner }}",
+                    repo: "{{ .Repo }}",
+                    issue: "{{ .Issue }}"
+                })
+            })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok')
+                }
+                return response
+            })
+            .then(response => response.json())
+            .then(data => {
+                const summaryHeader = "<sub>This is a AI generated summarization, powered by <a href=\"https://github.com/ioki-mobility/summaraizer\">summaraizer</a>:</sub></br></br>"
+                const summaryDecoded = atob(data.summarization)
+                document.querySelector('.comment-body').innerHTML = summaryHeader + summaryDecoded
+            })
+            .catch(_ => {
+                document.querySelector('.comment-body').innerHTML = "☠️ Something went wrong ☠️"
+            })
+        }
+    </script>
 </head>
 <body>
     <div class="comment-container">
@@ -84,13 +116,12 @@ To be specific by v0.dev!
         <div class="comment-content">
             <div class="comment-header">
                 <div class="comment-meta">
-                    <span class="comment-author">StefMa</span>
+                    <span class="comment-author">GitHubSummary[bot]</span>
                     <span class="comment-time">just now</span>
                 </div>
             </div>
             <div class="comment-body">
-                <sub>This is a AI generated summarization, powered by <a href="https://github.com/ioki-mobility/summaraizer">summaraizer</a>:</sub></br></br>
-                {{ . }}
+                <img src="https://i.imgur.com/VwXmegS.gif" width="22"/>
             </div>
         </div>
     </div>

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
     {
       "source": "/:owner/:repo/pull/:issue",
       "destination": "/api/index"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/api/404"
     }
   ]
 }


### PR DESCRIPTION
fixes #1 

However, this is not done yet as this delayes the loading time of the page.
We migth want to load the page, add "Thinkining..." to the comment box and do an API call that makes the summary.
As soon as the sumary returns, we replace the Thinking with the summary.

The UI looks like that right now:
![Screenshot 2024-08-28 at 1 48 45 PM](https://github.com/user-attachments/assets/661035f9-b178-45fa-aa70-f2cfc1e663bd)

We also want to replace the author `StefMa` with "GitHubSummary[bot]" (matches how dependabot look like) 🤔 
